### PR TITLE
Fixed Self-XSS for unescaped User-Agent

### DIFF
--- a/ban-options.php
+++ b/ban-options.php
@@ -269,7 +269,7 @@ $banned_options = get_option( 'banned_options' );
         </tr>
         <tr>
             <td><?php _e('User Agent', 'wp-ban'); ?>:</td>
-            <td><strong><?php echo $_SERVER['HTTP_USER_AGENT']; ?></strong></td>
+            <td><strong><?php echo (!isset($_SERVER["HTTP_USER_AGENT"]) ? __('Unknown', 'wp-ban') : htmlentities(strip_tags($_SERVER['HTTP_USER_AGENT']))); ?></strong></td>
         </tr>
         <tr class="alternate">
             <td><?php _e('Site URL', 'wp-ban'); ?>:</td>

--- a/ban-options.php
+++ b/ban-options.php
@@ -269,7 +269,7 @@ $banned_options = get_option( 'banned_options' );
         </tr>
         <tr>
             <td><?php _e('User Agent', 'wp-ban'); ?>:</td>
-            <td><strong><?php echo (!isset($_SERVER["HTTP_USER_AGENT"]) ? __('Unknown', 'wp-ban') : htmlentities(strip_tags($_SERVER['HTTP_USER_AGENT']))); ?></strong></td>
+            <td><strong><?php echo (!isset($_SERVER["HTTP_USER_AGENT"]) ? __('Unknown', 'wp-ban') : esc_html($_SERVER['HTTP_USER_AGENT'])); ?></strong></td>
         </tr>
         <tr class="alternate">
             <td><?php _e('Site URL', 'wp-ban'); ?>:</td>


### PR DESCRIPTION
Hello,

Just found this small bug.

Before:
![image](https://user-images.githubusercontent.com/34169065/143044659-57cbdeea-cd45-430d-a111-36367f071ad2.png)

After:
![image](https://user-images.githubusercontent.com/34169065/143044557-17db3733-e9fb-4f88-9ad7-917f8f16a7ea.png)

Hope it helps!