### PR TITLE
Make UI strings consistency

### DIFF
--- a/ban-options.php
+++ b/ban-options.php
@@ -328,7 +328,7 @@ $banned_options = get_option( 'banned_options' );
         <tr>
             <td valign="top">
                 <strong><?php _e('Banned Host Names', 'wp-ban'); ?>:</strong><br />
-                <?php _e('Use <strong>*</strong> for wildcards', 'wp-ban'); ?>.<br />
+                <?php _e('Use <strong>*</strong> for wildcards.', 'wp-ban'); ?><br />
                 <?php _e('Start each entry on a new line.', 'wp-ban'); ?><br /><br />
                 <?php _e('Examples:', 'wp-ban'); ?>
                 <p style="margin: 2px 0"><strong>&raquo;</strong> <span dir="ltr">*.sg</span></p>
@@ -342,7 +342,7 @@ $banned_options = get_option( 'banned_options' );
         <tr>
             <td valign="top">
                 <strong><?php _e('Banned Referers', 'wp-ban'); ?>:</strong><br />
-                <?php _e('Use <strong>*</strong> for wildcards', 'wp-ban'); ?>.<br />
+                <?php _e('Use <strong>*</strong> for wildcards.', 'wp-ban'); ?><br />
                 <?php _e('Start each entry on a new line.', 'wp-ban'); ?><br /><br />
                 <?php _e('Examples:', 'wp-ban'); ?><br />
                 <strong>&raquo;</strong> <span dir="ltr">http://*.blogspot.com</span><br /><br />
@@ -356,7 +356,7 @@ $banned_options = get_option( 'banned_options' );
         <tr>
             <td valign="top">
                 <strong><?php _e('Banned User Agents', 'wp-ban'); ?>:</strong><br />
-                <?php _e('Use <strong>*</strong> for wildcards', 'wp-ban'); ?>.<br />
+                <?php _e('Use <strong>*</strong> for wildcards.', 'wp-ban'); ?><br />
                 <?php _e('Start each entry on a new line.', 'wp-ban'); ?><br /><br />
                 <?php _e('Examples:', 'wp-ban'); ?>
                 <p style="margin: 2px 0"><strong>&raquo;</strong> <span dir="ltr">EmailSiphon*</span></p>


### PR DESCRIPTION
There are 3 strings "Use <strong>*</strong> for wildcards" which should end with a dot, but their dots are left out of the strings.  These dots should be translated and the same with a UI string "Use <strong>*</strong> for wildcards."
Making this change will remove these 3 strings without dots and use the same translation belonging to "Use <strong>*</strong> for wildcards."